### PR TITLE
vmm: add allow(dead_code) to un-used method

### DIFF
--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -716,6 +716,9 @@ impl MemoryManager {
         Ok((memory_regions, memory_zones))
     }
 
+    // In Nanvix we load snapshot files with CoW semantics, so we don't need to pre-fill saved
+    // memory regions.
+    #[allow(dead_code)]
     fn fill_saved_regions(
         &mut self,
         file_path: PathBuf,


### PR DESCRIPTION
In Nanvix we load snapshot files with CoW semantics so we don't need to pre-fil saved memory regions. In this commit I silence a clippy warning about this method not being used.